### PR TITLE
Fix infinite loop

### DIFF
--- a/src/pages/accounts.vue
+++ b/src/pages/accounts.vue
@@ -78,6 +78,16 @@ export default {
 
       // Binary search to find the block number that gets MAX_TRANSACTIONS.
       while (transactions === null || transactions.length < constants.WEB3_MAX_TRANSACTIONS - 1) {
+
+        // If the range is too small, find the first non-null result.
+        if (range[1] - range[0] <= 1) {
+          let i = 0;
+          while (transactions === null) {
+            transactions = await this.getTransactions(midpoint + i++, latest);
+          }
+          break;
+        }
+
         if (transactions === null) {
           // Still too many transactions.
           range[0] = midpoint;


### PR DESCRIPTION
# Contributors
@brandonLi8 @constanceshi 

# Relevant issue
#33  

# Summary of change
Added the condition that if the binary search range is too small (<= 1 block number difference), return transactions if its not null to avoid potential infinite looping, or search from the midpoint upward to find the first non null transaction to return

# Testing plan
Since this is hard to reproduce, we manually tested it with a dummy data implementation trial manually and checked that it went into the while loop when appropriate and returned a nonnull array of transactions for the rest of the methods to execute on, and deleted this when pushing our changes
