### PR TITLE
Add max height/ scroll bar to addresses on summary page

### DIFF
--- a/src/components/Summary.vue
+++ b/src/components/Summary.vue
@@ -10,7 +10,7 @@
     >
       <img :src="require(`@/assets/${role.icon}`)">
       <h2> {{ role.name }} </h2>
-      <div>
+      <div class="role-addresses">
         <nuxt-link
           v-for="(address, addressIndex) in role.addresses"
           :key="addressIndex"
@@ -152,6 +152,11 @@ h1 {
   @media only screen and (max-width: $mobile-threshold) {
     grid-row: auto;
     grid-column: 1
+  }
+
+  .role-addresses {
+    max-height: 60px;
+    overflow-y: scroll;
   }
 }
 


### PR DESCRIPTION

# Summary of change
<!--- Describe the change that this pull request makes. (examples: "Added component/feature X", "Fixed bug Y" --->
<!--- Add screenshots here if relevant --->
Was requested to add scroll bar (for the minters) for  #121  and I forgot, so i quickly did it here.
now looks like
![image](https://user-images.githubusercontent.com/42391580/99898306-a06cd600-2c5d-11eb-9ebe-cbbbc2c70e1a.png)


# Testing plan
<!--- How did you test your change? Reference any files you changed/added here. --->

N/a