### PR TITLE
keep-contract-env-optional

### DIFF
--- a/src/api/rest.js
+++ b/src/api/rest.js
@@ -7,7 +7,7 @@ const bigqueryClient = new BigQuery();
 app.use(bodyParser.json());
 
 app.get('/minters', async (req, res) => {
-  if (process.env.USDC_CONTRACT_ADDRESS && process.env.USDC_CONTRACT_ADDRESS !== '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48') {
+  if (req.query.contract !== '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48') {
     return res.json([]);
   }
 

--- a/src/pages/index.vue
+++ b/src/pages/index.vue
@@ -13,7 +13,7 @@
 
 <script>
 import Summary from '@/components/Summary';
-import { API_BASE_URL } from '@/utils/constants';
+import { API_BASE_URL, USDC_CONTRACT_ADDRESS } from '@/utils/constants';
 import { toHex } from '@/utils/utils';
 import { web3, contract, getTransactions } from '@/utils/web3utils';
 
@@ -75,8 +75,8 @@ export default {
         role.addresses.push(address);
       }
 
-      // This is for hiding Minters section when not on Mainnet (since minters are fetch via 
-      // BigQuery rather than web3). This is a temporary solution, as there does not yet exist 
+      // This is for hiding Minters section when not on Mainnet (since minters are fetch via
+      // BigQuery rather than web3). This is a temporary solution, as there does not yet exist
       // a USDC BigQuery for Ropsten.
       if (addresses.length === 0) {
         this.roles = this.roles.filter(role => role.name !== roleName);
@@ -85,7 +85,7 @@ export default {
     async lookupRoles() {
       this.setAddresses('Owner', [await contract.methods.owner().call()]);
       this.setAddresses('Pauser', [await contract.methods.pauser().call()]);
-      this.setAddresses('Minters', await this.fetch(`${API_BASE_URL}/api/minters`));
+      this.setAddresses('Minters', await this.fetch(`${API_BASE_URL}/api/minters?contract=${USDC_CONTRACT_ADDRESS}`));
       this.setAddresses('Blacklister', [await contract.methods.blacklister().call()]);
     },
     async lookupBlocks() {


### PR DESCRIPTION
#153 hides minters when not on mainnet.

It checks it like:
```js
  if (process.env.USDC_CONTRACT_ADDRESS !== '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48') {
    return res.json([]);
  }
```

However, USDC_CONTRACT_ADDRESS should be optional (defaulting to mainnet) so when it isn't provided in the `.env` file, minters aren't shown.

This pr passes in the`USDC_CONTRACT_ADDRESS` constant from the front end to the backend as a query parameter.